### PR TITLE
SMOODEV-732: Bump @smooai/config-typescript to 1.0.18

### DIFF
--- a/.smooai-logs/output.ansi
+++ b/.smooai-logs/output.ansi
@@ -449,3 +449,47 @@
 ----------------------------------------------------------------------------------------------------
 ----------------------------------------------------------------------------------------------------
 ----------------------------------------------------------------------------------------------------
+{
+  "msg": "[1m[32mAn API error occurred: Status: 400 (undefined); Message: Bad Request[39m[22m",
+  "time": "[34m2026-04-27T20:33:43.531Z[39m",
+  "error": "Bad Request",
+  "errorDetails": [
+    {
+      "message": "Bad Request",
+      "name": "Error",
+      "stack": "Error: Bad Request\n    at /Users/brentrager/dev/smooai/utils/src/api/sqsHandler.spec.ts:51:22\n    at file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:103:11\n    at file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:595:26\n    at file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:877:20\n    at new Promise (<anonymous>)\n    at runWithTimeout (file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:850:10)\n    at runTest (file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:1345:12)\n    at processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at runSuite (file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:1491:8)\n    at runSuite (file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:1491:8)",
+      "status": 400
+    }
+  ],
+  "@message": "An API error occurred: Status: 400 (undefined); Message: Bad Request",
+  "@requestId": "test-request-id",
+  "@timestamp": "2026-04-27T20:33:43.531Z",
+  "LogLevel": "error",
+  "callerContext": {
+    "loggerName": "AwsServerLogger",
+    "stack": [
+      "/Users/brentrager/dev/smooai/utils/src/api/sqsHandler.ts:21:20",
+      "processTicksAndRejections (node:internal/process/task_queues:105:5)"
+    ]
+  },
+  "correlationId": "93660c7b-30f5-4938-b13b-1265626d6b9a",
+  "http": {
+    "request": {
+    }
+  },
+  "lambda": {
+    "requestId": "test-request-id"
+  },
+  "level": 50,
+  "name": "AwsServerLogger",
+  "nodeEnv": "test",
+  "queue": {
+    "messageApproximateReceiveCount": "1",
+    "messageId": "msg1"
+  },
+  "requestId": "93660c7b-30f5-4938-b13b-1265626d6b9a",
+  "traceId": "93660c7b-30f5-4938-b13b-1265626d6b9a"
+}
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     },
     "devDependencies": {
         "@changesets/cli": "^2.28.1",
-        "@smooai/config-typescript": "^1.0.16",
+        "@smooai/config-typescript": "^1.0.18",
         "@types/aws-lambda": "^8.10.119",
         "@types/jira-client": "^7.1.9",
         "@types/node": "^20.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,8 +50,8 @@ importers:
         specifier: ^2.28.1
         version: 2.28.1
       '@smooai/config-typescript':
-        specifier: ^1.0.16
-        version: 1.0.16(typescript@5.8.2)
+        specifier: ^1.0.18
+        version: 1.0.18(typescript@5.8.2)
       '@types/aws-lambda':
         specifier: ^8.10.119
         version: 8.10.147
@@ -1101,8 +1101,8 @@ packages:
     resolution: {integrity: sha512-mEu1/UIXAdNYuBcyEPbjScKi/+MQVXNIuY/7Cm5XLIWe319kDrT5SizBE95jqtmEXoDbGoZxKLCMttdZdqTZKQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smooai/config-typescript@1.0.16':
-    resolution: {integrity: sha512-/JtA7zXUN0wfFIFd5NKPDIJ5z/O07CbLJwQwcbCXXdZ9MebjMssyccG/cQrQ6D/CMciV9fmBVJeoYDQlDjSGIg==}
+  '@smooai/config-typescript@1.0.18':
+    resolution: {integrity: sha512-wpsuhrpiLQ8/1pfrWOqxyqAXaKKiv/WDW+LepRN9xXs9jtMWjDNtsIpytU3KB/yHHDLU/ltZThzlbiAA+/xJTw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       typescript: ^5.8.2
@@ -3909,7 +3909,7 @@ snapshots:
       '@smithy/util-buffer-from': 4.1.0
       tslib: 2.8.1
 
-  '@smooai/config-typescript@1.0.16(typescript@5.8.2)':
+  '@smooai/config-typescript@1.0.18(typescript@5.8.2)':
     dependencies:
       typescript: 5.8.2
 


### PR DESCRIPTION
## Summary
Picks up `ignoreDeprecations: '5.0'` from `base.json` (PR SmooAI/config-typescript#75) which silences the baseUrl deprecation that's failing main CI post-SMOODEV-730.

## Context
- SMOODEV-730 #134 merged the Node 24 env var change. CI's TS now treats baseUrl as a hard error.
- SmooAI/config-typescript v1.0.18 ships the silencing flag in the shared base.json.
- Utils only needed a dep bump to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)