### PR TITLE
SMOODEV-928: Fix tsconfig baseUrl deprecation blocking release

### DIFF
--- a/.smooai-logs/output.ansi
+++ b/.smooai-logs/output.ansi
@@ -943,3 +943,228 @@
 ----------------------------------------------------------------------------------------------------
 ----------------------------------------------------------------------------------------------------
 ----------------------------------------------------------------------------------------------------
+{
+  "msg": "[1m[32mAn API error occurred: Status: 400 (undefined); Message: Bad Request[39m[22m",
+  "time": "[34m2026-05-12T03:09:15.569Z[39m",
+  "error": "Bad Request",
+  "errorDetails": [
+    {
+      "message": "Bad Request",
+      "name": "Error",
+      "stack": "Error: Bad Request\n    at /Users/brentrager/dev/smooai/utils/src/api/sqsHandler.spec.ts:51:22\n    at file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:103:11\n    at file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:595:26\n    at file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:877:20\n    at new Promise (<anonymous>)\n    at runWithTimeout (file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:850:10)\n    at runTest (file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:1345:12)\n    at processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at runSuite (file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:1491:8)\n    at runSuite (file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:1491:8)",
+      "status": 400
+    }
+  ],
+  "@message": "An API error occurred: Status: 400 (undefined); Message: Bad Request",
+  "@requestId": "test-request-id",
+  "@timestamp": "2026-05-12T03:09:15.569Z",
+  "LogLevel": "error",
+  "callerContext": {
+    "loggerName": "AwsServerLogger",
+    "stack": [
+      "/Users/brentrager/dev/smooai/utils/src/api/sqsHandler.ts:21:20",
+      "processTicksAndRejections (node:internal/process/task_queues:105:5)"
+    ]
+  },
+  "correlationId": "d05be0a9-7db8-46eb-85e7-2ecb5c5cea2c",
+  "http": {
+    "request": {
+    }
+  },
+  "lambda": {
+    "requestId": "test-request-id"
+  },
+  "level": 50,
+  "name": "AwsServerLogger",
+  "nodeEnv": "test",
+  "queue": {
+    "messageApproximateReceiveCount": "1",
+    "messageId": "msg1"
+  },
+  "requestId": "d05be0a9-7db8-46eb-85e7-2ecb5c5cea2c",
+  "traceId": "d05be0a9-7db8-46eb-85e7-2ecb5c5cea2c"
+}
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+{
+  "msg": "[1m[32mA schema validation error occurred: Invalid schema at \"test\"[39m[22m",
+  "time": "[34m2026-05-12T03:09:15.572Z[39m",
+  "error": "Invalid schema at \"test\"",
+  "errorDetails": [
+    {
+      "message": "Invalid schema at \"test\"",
+      "name": "HumanReadableSchemaError",
+      "schemaError": {
+        "issues": [
+          {
+            "message": "Invalid schema",
+            "path": [
+              "test"
+            ]
+          }
+        ],
+        "message": "Invalid schema",
+        "name": "SchemaError",
+        "stack": "SchemaError: Invalid schema\n    at /Users/brentrager/dev/smooai/utils/src/api/sqsHandler.spec.ts:62:25\n    at file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:103:11\n    at file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:595:26\n    at file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:877:20\n    at new Promise (<anonymous>)\n    at runWithTimeout (file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:850:10)\n    at runTest (file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:1345:12)\n    at processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at runSuite (file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:1491:8)\n    at runSuite (file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:1491:8)"
+      },
+      "stack": "HumanReadableSchemaError: Invalid schema at \"test\"\n    at /Users/brentrager/dev/smooai/utils/src/api/sqsHandler.spec.ts:63:32\n    at file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:103:11\n    at file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:595:26\n    at file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:877:20\n    at new Promise (<anonymous>)\n    at runWithTimeout (file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:850:10)\n    at runTest (file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:1345:12)\n    at processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at runSuite (file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:1491:8)\n    at runSuite (file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:1491:8)"
+    }
+  ],
+  "@message": "A schema validation error occurred: Invalid schema at \"test\"",
+  "@requestId": "test-request-id",
+  "@timestamp": "2026-05-12T03:09:15.572Z",
+  "LogLevel": "error",
+  "callerContext": {
+    "loggerName": "AwsServerLogger",
+    "stack": [
+      "/Users/brentrager/dev/smooai/utils/src/api/sqsHandler.ts:23:20",
+      "processTicksAndRejections (node:internal/process/task_queues:105:5)"
+    ]
+  },
+  "correlationId": "f84dc99b-7e83-4244-ab12-3d4d514bbe36",
+  "http": {
+    "request": {
+    }
+  },
+  "lambda": {
+    "requestId": "test-request-id"
+  },
+  "level": 50,
+  "name": "AwsServerLogger",
+  "nodeEnv": "test",
+  "queue": {
+    "messageApproximateReceiveCount": "1",
+    "messageId": "msg1"
+  },
+  "requestId": "f84dc99b-7e83-4244-ab12-3d4d514bbe36",
+  "traceId": "f84dc99b-7e83-4244-ab12-3d4d514bbe36"
+}
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+{
+  "msg": "[1m[32mA validation error occurred: ✖ Expected string, received number\n  → at name[39m[22m",
+  "time": "[34m2026-05-12T03:09:15.573Z[39m",
+  "@message": "A validation error occurred: ✖ Expected string, received number\n  → at name",
+  "@requestId": "test-request-id",
+  "@timestamp": "2026-05-12T03:09:15.573Z",
+  "LogLevel": "error",
+  "callerContext": {
+    "loggerName": "AwsServerLogger",
+    "stack": [
+      "/Users/brentrager/dev/smooai/utils/src/api/sqsHandler.ts:26:20",
+      "processTicksAndRejections (node:internal/process/task_queues:105:5)"
+    ]
+  },
+  "context": {
+    "message": "[\n  {\n    \"code\": \"invalid_type\",\n    \"expected\": \"string\",\n    \"path\": [\n      \"name\"\n    ],\n    \"message\": \"Expected string, received number\"\n  }\n]",
+    "name": "ZodError"
+  },
+  "correlationId": "7d5cc86d-9d00-47f9-89a2-a862c9c768f1",
+  "http": {
+    "request": {
+    }
+  },
+  "lambda": {
+    "requestId": "test-request-id"
+  },
+  "level": 50,
+  "name": "AwsServerLogger",
+  "nodeEnv": "test",
+  "queue": {
+    "messageApproximateReceiveCount": "1",
+    "messageId": "msg1"
+  },
+  "requestId": "7d5cc86d-9d00-47f9-89a2-a862c9c768f1",
+  "traceId": "7d5cc86d-9d00-47f9-89a2-a862c9c768f1"
+}
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+{
+  "msg": "[1m[32mAn unexpected error occurred: General error[39m[22m",
+  "time": "[34m2026-05-12T03:09:15.573Z[39m",
+  "error": "General error",
+  "errorDetails": [
+    {
+      "message": "General error",
+      "name": "Error",
+      "stack": "Error: General error\n    at /Users/brentrager/dev/smooai/utils/src/api/sqsHandler.spec.ts:92:19\n    at file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:103:11\n    at file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:595:26\n    at file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:877:20\n    at new Promise (<anonymous>)\n    at runWithTimeout (file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:850:10)\n    at runTest (file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:1345:12)\n    at processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at runSuite (file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:1491:8)\n    at runSuite (file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:1491:8)"
+    }
+  ],
+  "@message": "An unexpected error occurred: General error",
+  "@requestId": "test-request-id",
+  "@timestamp": "2026-05-12T03:09:15.573Z",
+  "LogLevel": "error",
+  "callerContext": {
+    "loggerName": "AwsServerLogger",
+    "stack": [
+      "/Users/brentrager/dev/smooai/utils/src/api/sqsHandler.ts:28:20",
+      "processTicksAndRejections (node:internal/process/task_queues:105:5)"
+    ]
+  },
+  "correlationId": "6dffff9e-3d27-4c64-a212-0abc55f8192f",
+  "http": {
+    "request": {
+    }
+  },
+  "lambda": {
+    "requestId": "test-request-id"
+  },
+  "level": 50,
+  "name": "AwsServerLogger",
+  "nodeEnv": "test",
+  "queue": {
+    "messageApproximateReceiveCount": "1",
+    "messageId": "msg1"
+  },
+  "requestId": "6dffff9e-3d27-4c64-a212-0abc55f8192f",
+  "traceId": "6dffff9e-3d27-4c64-a212-0abc55f8192f"
+}
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+{
+  "msg": "[1m[32mAn unexpected error occurred: Failed[39m[22m",
+  "time": "[34m2026-05-12T03:09:15.574Z[39m",
+  "error": "Failed",
+  "errorDetails": [
+    {
+      "message": "Failed",
+      "name": "Error",
+      "stack": "Error: Failed\n    at /Users/brentrager/dev/smooai/utils/src/api/sqsHandler.spec.ts:117:69\n    at file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:103:11\n    at file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:595:26\n    at file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:877:20\n    at new Promise (<anonymous>)\n    at runWithTimeout (file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:850:10)\n    at runTest (file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:1345:12)\n    at processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at runSuite (file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:1491:8)\n    at runSuite (file:///Users/brentrager/dev/smooai/utils/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:1491:8)"
+    }
+  ],
+  "@message": "An unexpected error occurred: Failed",
+  "@requestId": "test-request-id",
+  "@timestamp": "2026-05-12T03:09:15.574Z",
+  "LogLevel": "error",
+  "callerContext": {
+    "loggerName": "AwsServerLogger",
+    "stack": [
+      "/Users/brentrager/dev/smooai/utils/src/api/sqsHandler.ts:28:20",
+      "processTicksAndRejections (node:internal/process/task_queues:105:5)"
+    ]
+  },
+  "correlationId": "aabd3e64-cbdc-4154-aeea-1cc7417d129e",
+  "http": {
+    "request": {
+    }
+  },
+  "lambda": {
+    "requestId": "test-request-id"
+  },
+  "level": 50,
+  "name": "AwsServerLogger",
+  "nodeEnv": "test",
+  "queue": {
+    "messageApproximateReceiveCount": "1",
+    "messageId": "msg2"
+  },
+  "requestId": "aabd3e64-cbdc-4154-aeea-1cc7417d129e",
+  "traceId": "aabd3e64-cbdc-4154-aeea-1cc7417d129e"
+}
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
         "oxlint": "^0.16.0",
         "picocolors": "^1.1.1",
         "tsup": "^8.4.0",
+        "typescript": "^5.8.2",
         "vite": "^6.2.4",
         "vite-node": "^3.1.1",
         "vite-tsconfig-paths": "^5.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,9 @@ importers:
       tsup:
         specifier: ^8.4.0
         version: 8.4.0(postcss@8.5.3)(typescript@5.8.2)(yaml@2.7.0)
+      typescript:
+        specifier: ^5.8.2
+        version: 5.8.2
       vite:
         specifier: ^6.2.4
         version: 6.2.4(@types/node@20.17.24)(yaml@2.7.0)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,12 +5,8 @@
         "outDir": "./dist",
         "types": ["node"],
         "target": "ES2022",
-        "baseUrl": "./",
-        "ignoreDeprecations": "5.0",
         "paths": {
-            "@smooai/logger/*": ["../logger/src/*"],
-            "@smooai/utils/*": ["../utils/src/*"],
-            "@/*": ["src/*"]
+            "@/*": ["./src/*"]
         }
     },
     "include": ["./src/**/*.ts", "./src/**/*.tsx", "src/index.ts", "index.ts", "tsup.config.ts"],


### PR DESCRIPTION
## Summary
- The SMOODEV-928 logger bump landed on main but release.yml failed because TS 5.9+/6.x rejects \`baseUrl + ignoreDeprecations: "5.0"\` (TS5101). That blocked publishing 1.3.3 to npm.
- Strips \`baseUrl\` and rewrites the only used path alias (\`@/*\`) to relative \`./src/*\`. \`@smooai/logger/*\` and \`@smooai/utils/*\` aliases were vestigial dev-link entries — unused in sources.
- Pins \`typescript\` as an explicit devDep so \`node_modules/.bin/tsc\` resolves locally (matches fetch/file/config).

## Test plan
- [x] \`pnpm typecheck\` (passes; previously failed in CI with TS5101)
- [x] \`pnpm test\` / \`pnpm build\` already validated on the prior PR

After merge, release.yml should publish utils@1.3.3 with the logger 4.1.4 bump from PR #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)