### PR TITLE
Enable smooth-agent@smooth plugin (pearl th-492b45)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,11 +4,21 @@
         "PreToolUse": [
             {
                 "matcher": "Edit|Write",
-                "hooks": [{ "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-worktree.sh" }]
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-worktree.sh"
+                    }
+                ]
             },
             {
                 "matcher": "Bash",
-                "hooks": [{ "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-worktree.sh" }]
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-worktree.sh"
+                    }
+                ]
             }
         ],
         "SessionStart": [
@@ -17,10 +27,21 @@
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "BRANCH=$(git -C \"$CLAUDE_PROJECT_DIR\" symbolic-ref --short HEAD 2>/dev/null); if [[ \"$BRANCH\" == \"main\" || \"$BRANCH\" == \"master\" ]]; then REPO_NAME=$(basename \"$CLAUDE_PROJECT_DIR\"); echo \"⚠️  You are in the MAIN worktree on the main branch. Do NOT do feature work here. Create a worktree first: git worktree add ../${REPO_NAME}-SMOODEV-XX-desc -b SMOODEV-XX-desc main\"; fi"
+                        "command": "BRANCH=$(git -C \"$CLAUDE_PROJECT_DIR\" symbolic-ref --short HEAD 2>/dev/null); if [[ \"$BRANCH\" == \"main\" || \"$BRANCH\" == \"master\" ]]; then REPO_NAME=$(basename \"$CLAUDE_PROJECT_DIR\"); echo \"\u26a0\ufe0f  You are in the MAIN worktree on the main branch. Do NOT do feature work here. Create a worktree first: git worktree add ../${REPO_NAME}-SMOODEV-XX-desc -b SMOODEV-XX-desc main\"; fi"
                     }
                 ]
             }
         ]
+    },
+    "extraKnownMarketplaces": {
+        "smooth": {
+            "source": {
+                "source": "github",
+                "repo": "SmooAI/smooth"
+            }
+        }
+    },
+    "enabledPlugins": {
+        "smooth-agent@smooth": true
     }
 }


### PR DESCRIPTION
Adds the smooth marketplace + enables the shared SmooAI Claude Code guardrails/skills plugin so this repo's Claude sessions get the same worktree/curl/pearls guardrails, the new pearl-store read-only-wedge guard, and the windows-build-box skill.

Settings-only; merges into existing `.claude/settings.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)