### PR TITLE
Drop legacy inline .claude/hooks — plugin provides them (th-147c83)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,38 +1,5 @@
 {
     "$schema": "https://json.schemastore.org/claude-code-settings.json",
-    "hooks": {
-        "PreToolUse": [
-            {
-                "matcher": "Edit|Write",
-                "hooks": [
-                    {
-                        "type": "command",
-                        "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-worktree.sh"
-                    }
-                ]
-            },
-            {
-                "matcher": "Bash",
-                "hooks": [
-                    {
-                        "type": "command",
-                        "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-worktree.sh"
-                    }
-                ]
-            }
-        ],
-        "SessionStart": [
-            {
-                "matcher": "startup",
-                "hooks": [
-                    {
-                        "type": "command",
-                        "command": "BRANCH=$(git -C \"$CLAUDE_PROJECT_DIR\" symbolic-ref --short HEAD 2>/dev/null); if [[ \"$BRANCH\" == \"main\" || \"$BRANCH\" == \"master\" ]]; then REPO_NAME=$(basename \"$CLAUDE_PROJECT_DIR\"); echo \"\u26a0\ufe0f  You are in the MAIN worktree on the main branch. Do NOT do feature work here. Create a worktree first: git worktree add ../${REPO_NAME}-SMOODEV-XX-desc -b SMOODEV-XX-desc main\"; fi"
-                    }
-                ]
-            }
-        ]
-    },
     "extraKnownMarketplaces": {
         "smooth": {
             "source": {


### PR DESCRIPTION
The `smooth-agent@smooth` plugin now supplies the shared guardrail hooks (worktree enforcement, th-curl-hint, pearls-labels, pearls-store-guard), so this repo's hand-copied inline `hooks` block in `.claude/settings.json` double-fires. Removed the inline block; kept the marketplace + `enabledPlugins`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)